### PR TITLE
Handle Unicode names in ClassCardsApp

### DIFF
--- a/src/ClassCardsApp.jsx
+++ b/src/ClassCardsApp.jsx
@@ -25,8 +25,8 @@ function parseNameColor(text) {
     white: 'white',
   };
   const regex = new RegExp(
-    `\\b(\\w+)\\b\\s+(${Object.keys(colorMap).join('|')})`,
-    'i'
+    `\\b([\\p{L} ]+)\\b\\s+(${Object.keys(colorMap).join('|')})`,
+    'iu'
   );
   const match = text.toLowerCase().match(regex);
   if (match) {


### PR DESCRIPTION
## Summary
- enable parsing of names with spaces and accents using Unicode-aware regex

## Testing
- `node <<'NODE'
const colorMap = {vermelho:'red', vermelha:'red', azul:'blue', verde:'green', amarelo:'yellow', amarela:'yellow', preto:'black', preta:'black', branco:'white', branca:'white', red:'red', blue:'blue', green:'green', yellow:'yellow', black:'black', white:'white'};
const regex = new RegExp(`\\b([\\p{L} ]+)\\b\\s+(${Object.keys(colorMap).join('|')})`, 'iu');
const text1='Ana Júlia vermelho';
const text2='João Pedro azul';
console.log(text1.toLowerCase().match(regex));
console.log(text2.toLowerCase().match(regex));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a66a1c8b2c83309b5c510536c46fc2