### PR TITLE
Implementa lógica real de envio de cartão

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # wandy-s
+
+## ClassCardsApp
+
+O componente `ClassCardsApp` utiliza reconhecimento de voz para identificar
+comandos no formato "nome cor" e, ao reconhecer com sucesso, envia uma
+requisição `POST /api/cards` para registrar um cartão entregue. Em caso de
+sucesso ou erro na chamada, uma mensagem de feedback é exibida na interface.

--- a/src/ClassCardsApp.jsx
+++ b/src/ClassCardsApp.jsx
@@ -35,13 +35,25 @@ function parseNameColor(text) {
   return {};
 }
 
-function giveCard(name, color, qty) {
-  // Placeholder implementation for integration with existing app logic
-  console.log(`giveCard called with`, name, color, qty);
+// Dispara a requisição para registrar um cartão entregue.
+// Retorna a resposta da API ou lança um erro em caso de falha.
+async function giveCard(name, color, qty) {
+  const response = await fetch('/api/cards', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, color, qty })
+  });
+
+  if (!response.ok) {
+    throw new Error('Falha ao registrar o cartão');
+  }
+
+  return response.json();
 }
 
 export default function ClassCardsApp() {
   const [listening, setListening] = useState(false);
+  const [feedback, setFeedback] = useState('');
   const recognitionRef = useRef(null);
 
   useEffect(() => {
@@ -54,13 +66,19 @@ export default function ClassCardsApp() {
     recognition.continuous = true;
     recognition.interimResults = false;
 
-    recognition.onresult = event => {
+    recognition.onresult = async event => {
       const transcript = Array.from(event.results)
         .map(result => result[0].transcript)
         .join(' ');
       const { name, color } = parseNameColor(transcript);
       if (name && color) {
-        giveCard(name, color, 1);
+        try {
+          await giveCard(name, color, 1);
+          setFeedback(`Cartão enviado para ${name} (${color}).`);
+        } catch (error) {
+          console.error('Erro ao dar o cartão', error);
+          setFeedback('Não foi possível enviar o cartão.');
+        }
       }
     };
 
@@ -98,6 +116,7 @@ export default function ClassCardsApp() {
         {listening ? 'Desativar microfone' : 'Ativar microfone'}
       </button>
       <p>Status: {listening ? 'listening' : 'paused'}</p>
+      {feedback && <p>{feedback}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implementa `giveCard` com chamada POST para `/api/cards`
- exibe mensagem de sucesso ou falha ao reconhecer voz
- documenta comportamento do componente

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66a1e1fc083308af13a4b91ce214d